### PR TITLE
feat!: adding metadata to workers

### DIFF
--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -144,6 +144,12 @@ class Queue(ABC):
         pass
 
     @abstractmethod
+    async def write_worker_metadata(
+        self, worker_id: str, queue_key: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        pass
+
+    @abstractmethod
     async def _retry(self, job: Job, error: str | None) -> None:
         pass
 

--- a/saq/queue/http.py
+++ b/saq/queue/http.py
@@ -107,6 +107,14 @@ class HttpProxy:
                     worker_id=req["worker_id"], stats=req["stats"], ttl=req["ttl"]
                 )
                 return None
+            if kind == "write_worker_metadata":
+                await self.queue.write_worker_metadata(
+                    metadata=req["metadata"],
+                    ttl=req["ttl"],
+                    queue_key=req["queue_key"],
+                    worker_id=req["worker_id"],
+                )
+                return None
         raise ValueError(f"Invalid request {body}")
 
 
@@ -210,6 +218,17 @@ class HttpQueue(Queue):
 
     async def write_stats(self, worker_id: str, stats: WorkerStats, ttl: int) -> None:
         await self._send("write_stats", worker_id=worker_id, stats=stats, ttl=ttl)
+
+    async def write_worker_metadata(
+        self, worker_id: str, queue_key: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        await self._send(
+            "write_worker_metadata",
+            worker_id=worker_id,
+            metadata=metadata,
+            ttl=ttl,
+            queue_key=queue_key,
+        )
 
     async def info(self, jobs: bool = False, offset: int = 0, limit: int = 10) -> QueueInfo:
         return json.loads(await self._send("info", jobs=jobs, offset=offset, limit=limit))

--- a/saq/queue/http.py
+++ b/saq/queue/http.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 import typing as t
 
-
 from saq.errors import MissingDependencyError
 from saq.job import Job, Status
 from saq.queue.base import Queue
@@ -18,7 +17,7 @@ if t.TYPE_CHECKING:
     from saq.types import (
         CountKind,
         QueueInfo,
-        WorkerStats,
+        WorkerInfo,
     )
 
 try:
@@ -102,17 +101,15 @@ class HttpProxy:
                         jobs=req["jobs"], offset=req["offset"], limit=req["limit"]
                     )
                 )
-            if kind == "write_stats":
-                await self.queue.write_stats(
-                    worker_id=req["worker_id"], stats=req["stats"], ttl=req["ttl"]
-                )
-                return None
-            if kind == "write_worker_metadata":
-                await self.queue.write_worker_metadata(
-                    metadata=req["metadata"],
-                    ttl=req["ttl"],
-                    queue_key=req["queue_key"],
+            if kind == "write_worker_info":
+                await self.queue.write_worker_info(
                     worker_id=req["worker_id"],
+                    info={
+                        "stats": req["stats"],
+                        "queue_key": req["queue_key"],
+                        "metadata": req["metadata"],
+                    },
+                    ttl=req["ttl"],
                 )
                 return None
         raise ValueError(f"Invalid request {body}")
@@ -216,18 +213,19 @@ class HttpQueue(Queue):
     async def dequeue(self, timeout: float = 0) -> Job | None:
         return self.deserialize(await self._send("dequeue", timeout=timeout))
 
-    async def write_stats(self, worker_id: str, stats: WorkerStats, ttl: int) -> None:
-        await self._send("write_stats", worker_id=worker_id, stats=stats, ttl=ttl)
-
-    async def write_worker_metadata(
-        self, worker_id: str, queue_key: str, metadata: t.Optional[dict], ttl: int
+    async def write_worker_info(
+        self,
+        worker_id: str,
+        info: WorkerInfo,
+        ttl: int,
     ) -> None:
         await self._send(
-            "write_worker_metadata",
+            "write_worker_info",
             worker_id=worker_id,
-            metadata=metadata,
+            stats=info["stats"],
             ttl=ttl,
-            queue_key=queue_key,
+            queue_key=info["queue_key"],
+            metadata=info["metadata"],
         )
 
     async def info(self, jobs: bool = False, offset: int = 0, limit: int = 10) -> QueueInfo:

--- a/saq/queue/postgres_migrations.py
+++ b/saq/queue/postgres_migrations.py
@@ -7,7 +7,6 @@ from textwrap import dedent
 def get_migrations(
     jobs_table: Identifier,
     stats_table: Identifier,
-    worker_metadata_table: Identifier,
 ) -> t.List[t.Tuple[int, t.List[Composed]]]:
     return [
         (
@@ -49,14 +48,12 @@ CREATE TABLE IF NOT EXISTS {stats_table} (
             [
                 SQL(
                     dedent("""
-        CREATE TABLE IF NOT EXISTS {worker_metadata_table} (
-            worker_id TEXT PRIMARY KEY,
-            queue_key TEXT NOT NULL,
-            expire_at BIGINT NOT NULL,
-            metadata JSONB
-        );
+ALTER TABLE {stats_table} ADD COLUMN IF NOT EXISTS metadata JSONB;
+ALTER TABLE {stats_table} ADD COLUMN IF NOT EXISTS queue_key TEXT;
+CREATE INDEX IF NOT EXISTS saq_stats_expire_at_idx ON {stats_table} (expire_at);
+CREATE INDEX IF NOT EXISTS saq_stats_queue_key_idx ON {stats_table} (queue_key);
         """)
-                ).format(worker_metadata_table=worker_metadata_table),
+                ).format(stats_table=stats_table),
             ],
         ),
     ]

--- a/saq/queue/postgres_migrations.py
+++ b/saq/queue/postgres_migrations.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 def get_migrations(
     jobs_table: Identifier,
     stats_table: Identifier,
+    worker_metadata_table: Identifier,
 ) -> t.List[t.Tuple[int, t.List[Composed]]]:
     return [
         (
@@ -41,6 +42,21 @@ CREATE TABLE IF NOT EXISTS {stats_table} (
 );
 """)
                 ).format(stats_table=stats_table),
+            ],
+        ),
+        (
+            2,
+            [
+                SQL(
+                    dedent("""
+        CREATE TABLE IF NOT EXISTS {worker_metadata_table} (
+            worker_id TEXT PRIMARY KEY,
+            queue_key TEXT NOT NULL,
+            expire_at BIGINT NOT NULL,
+            metadata JSONB
+        );
+        """)
+                ).format(worker_metadata_table=worker_metadata_table),
             ],
         ),
     ]

--- a/saq/types.py
+++ b/saq/types.py
@@ -45,12 +45,22 @@ class JobTaskContext(t.TypedDict, total=False):
     "If this task has been aborted, this is the reason"
 
 
+class WorkerInfo(t.TypedDict):
+    """
+    Worker Info
+    """
+
+    queue_key: t.Optional[str]
+    stats: t.Optional[WorkerStats]
+    metadata: t.Optional[dict[str, t.Any]]
+
+
 class QueueInfo(t.TypedDict):
     """
     Queue Info
     """
 
-    workers: dict[str, dict[str, t.Any]]
+    workers: dict[str, WorkerInfo]
     "Worker information"
     name: str
     "Queue name"
@@ -93,6 +103,8 @@ class TimersDict(t.TypedDict):
     "How often to clean up stuck jobs in seconds (default 60)"
     abort: int
     "How often to check if a job is aborted in seconds (default 1)"
+    metadata: int
+    "How often to write worker metadata in seconds (default 60)"
 
 
 class PartialTimersDict(TimersDict, total=False):

--- a/saq/types.py
+++ b/saq/types.py
@@ -97,14 +97,12 @@ class TimersDict(t.TypedDict):
 
     schedule: int
     "How often we poll to schedule jobs in seconds (default 1)"
-    stats: int
-    "How often to update stats in seconds (default 10)"
+    worker_info: int
+    "How often to update worker info, stats and metadata in seconds (default 10)"
     sweep: int
     "How often to clean up stuck jobs in seconds (default 60)"
     abort: int
     "How often to check if a job is aborted in seconds (default 1)"
-    metadata: int
-    "How often to write worker metadata in seconds (default 60)"
 
 
 class PartialTimersDict(TimersDict, total=False):

--- a/tests/test_http_stats.py
+++ b/tests/test_http_stats.py
@@ -48,17 +48,17 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
             queue=queue1,
             functions=[echo],
         )
-        await worker.stats()
+        await worker.worker_info()
         worker2 = Worker(
             queue=queue2,
             functions=[echo],
         )
-        await worker2.stats()
+        await worker2.worker_info()
         local_worker = Worker(
             queue=self.queue,
             functions=[echo],
         )
-        await local_worker.stats()
+        await local_worker.worker_info()
 
         root_info = await self.queue.info()
         info1 = await queue1.info()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -10,7 +10,6 @@ class TestMigrations(unittest.TestCase):
         migrations = get_migrations(
             Identifier("jobs_table"),
             Identifier("stats_table"),
-            Identifier("worker_metadata_table"),
         )
         versions = [migration[0] for migration in migrations]
         assert versions == sorted(versions)
@@ -20,7 +19,6 @@ class TestMigrations(unittest.TestCase):
         migrations = get_migrations(
             Identifier("jobs_table"),
             Identifier("stats_table"),
-            Identifier("worker_metadata_table"),
         )
         versions = [migration[0] for migration in migrations]
         assert max(versions) <= len(migrations)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,16 +1,26 @@
 import unittest
 
+from psycopg.sql import Identifier
+
 from saq.queue.postgres_migrations import get_migrations
 
 
 class TestMigrations(unittest.TestCase):
     def test_migration_versions_are_increasing(self) -> None:
-        migrations = get_migrations("jobs_table", "stats_table")
+        migrations = get_migrations(
+            Identifier("jobs_table"),
+            Identifier("stats_table"),
+            Identifier("worker_metadata_table"),
+        )
         versions = [migration[0] for migration in migrations]
         assert versions == sorted(versions)
         assert len(versions) == len(set(versions))
 
     def test_highest_migration_equal_or_smaller_than_length(self) -> None:
-        migrations = get_migrations("jobs_table", "stats_table")
+        migrations = get_migrations(
+            Identifier("jobs_table"),
+            Identifier("stats_table"),
+            Identifier("worker_metadata_table"),
+        )
         versions = [migration[0] for migration in migrations]
         assert max(versions) <= len(migrations)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -201,12 +201,12 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
             await job.finish(Status.ABORTED)
             await job.finish(Status.FAILED)
             await job.finish(Status.COMPLETE)
-        stats = await worker.stats()
-        self.assertEqual(stats["complete"], 10)
-        self.assertEqual(stats["failed"], 10)
-        self.assertEqual(stats["retried"], 10)
-        self.assertEqual(stats["aborted"], 10)
-        self.assertGreater(stats["uptime"], 0)
+        worker_info = await worker.worker_info()
+        self.assertEqual(worker_info["stats"]["complete"], 10)
+        self.assertEqual(worker_info["stats"]["failed"], 10)
+        self.assertEqual(worker_info["stats"]["retried"], 10)
+        self.assertEqual(worker_info["stats"]["aborted"], 10)
+        self.assertGreater(worker_info["stats"]["uptime"], 0)
 
     async def test_info(self) -> None:
         queue2 = await self.create_queue(name=self.queue.name)
@@ -226,8 +226,7 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         await self.enqueue("echo", a=1)
         await queue2.enqueue("echo", a=1)
         await worker.process()
-        await worker.stats()
-        await worker.metadata(3)
+        await worker.worker_info(3)
 
         info = await self.queue.info(jobs=True)
         self.assertEqual(set(info["workers"].keys()), {worker.id})
@@ -239,9 +238,11 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(info["jobs"]), 1)
 
         time.sleep(4)
+        info = await self.queue.info(jobs=True)
+        self.assertEqual(info["workers"], {})
         await worker.queue.sweep()
         info = await self.queue.info(jobs=True)
-        self.assertEqual(info["workers"][worker.id]["metadata"], None)
+        self.assertEqual(info["workers"], {})
 
     @mock.patch("saq.utils.time")
     async def test_schedule(self, mock_time: MagicMock) -> None:
@@ -595,7 +596,7 @@ class TestPostgresQueue(TestQueue):
     async def test_sweep_stats(self) -> None:
         worker = Worker(self.queue, functions=functions)
         # Stats are deleted
-        await worker.stats(ttl=1)
+        await worker.worker_info(ttl=1)
         await asyncio.sleep(1.5)
         await self.queue.sweep()
         async with self.queue.pool.connection() as conn, conn.cursor() as cursor:
@@ -612,7 +613,7 @@ class TestPostgresQueue(TestQueue):
             self.assertIsNone(await cursor.fetchone())
 
         # Stats are not deleted
-        await worker.stats(ttl=60)
+        await worker.worker_info(ttl=60)
         await asyncio.sleep(1)
         await self.queue.sweep()
         async with self.queue.pool.connection() as conn, conn.cursor() as cursor:


### PR DESCRIPTION
feat!: adding metadata to workers

- alter table to store metadata in what is known as the stats table
- unify functions so that we only have really the concept of worker_info to simplify things